### PR TITLE
docker commandの大文字不可部分の対応

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,11 @@ jobs:
       - setup_remote_docker
 
       - run:
-          command: docker build -t '${CIRCLE_PROJECT_REPONAME,,}/${CIRCLE_PROJECT_USERNAME,,}:${CIRCLE_TAG}' .
+          command: docker build -t $(tr '[A-Z]' '[a-z]' <<<`${CIRCLE_PROJECT_REPONAME}/${CIRCLE_PROJECT_USERNAME}:${CIRCLE_TAG}`) .
       - run:
           command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
       - run:
-          command: docker push '${CIRCLE_PROJECT_REPONAME,,}/${CIRCLE_PROJECT_USERNAME,,}:${CIRCLE_TAG}'
+          command: docker push $(tr '[A-Z]' '[a-z]' <<<`${CIRCLE_PROJECT_REPONAME}/${CIRCLE_PROJECT_USERNAME}:${CIRCLE_TAG}`)
 
 workflows:
   version: 2

--- a/infrastructure/staging/gcp/terraform/main.tf
+++ b/infrastructure/staging/gcp/terraform/main.tf
@@ -89,5 +89,5 @@ resource "google_cloudbuild_trigger" "default" {
         _IMAGE_MANE = "${var.docker_image_name}"
     }
 
-    filename = "../cloudbuild.yml"
+    filename = "infrastructure/staging/gcp/cloudbuild.yml"
 }


### PR DESCRIPTION
- ${HOME,,}で変数の中の大文字を小文字にできるが、最近のVersion(bash)しか対応していないため、使用は気をつける。

- `$()`に包むことでコマンドを多重にできる

- `｀`に包むことで変数を展開して、文字列にまとめることができる
ex.
```
//$A=main
//$B=scala
//$C=Main
$ echo `${A}/${B}/${C}.scala`
main/scala/Main.scala
```