### PR TITLE
tag設定時のみdeployが走るようにする

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,11 +39,11 @@ jobs:
       - setup_remote_docker
 
       - run:
-          command: docker build -t $(`${CIRCLE_PROJECT_REPONAME}/${CIRCLE_PROJECT_USERNAME}:${CIRCLE_TAG}` | sed 's/.\+/\L\0/') .
+          command: docker build -t $(echo `${CIRCLE_PROJECT_REPONAME}/${CIRCLE_PROJECT_USERNAME}:${CIRCLE_TAG}` | sed 's/.\+/\L\0/') .
       - run:
           command: docker login -u ${DOCKER_USER} -p ${DOCKER_PASS}
       - run:
-          command: docker push $(`${CIRCLE_PROJECT_REPONAME}/${CIRCLE_PROJECT_USERNAME}:${CIRCLE_TAG}` | sed 's/.\+/\L\0/')
+          command: docker push $(echo `${CIRCLE_PROJECT_REPONAME}/${CIRCLE_PROJECT_USERNAME}:${CIRCLE_TAG}` | sed 's/.\+/\L\0/')
 
 workflows:
   version: 2
@@ -55,6 +55,6 @@ workflows:
             - build
           filters:
             branches:
-              only: develop
+              ignore: /.*/
             tags:
               only: /^[0-9]+\.[0-9]+\.[0-9]+$/


### PR DESCRIPTION
[公式より](https://circleci.com/docs/2.0/workflows/)
tagが設定されたもののみ`build`が実行されるようにするには、
すべてのブランチを`ignore`して、ビルドしてほしいタグ名を正規表現で記述するという2つの設定が必要